### PR TITLE
This PR adds new OPTIONAL vars to run_Precipitation and run_Temperature for BMI purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin/
 _build/
 _build2/
 include/
+prms_project/
 output/
 delaware_river/
 lib/

--- a/src/prms/Main_prms.f90
+++ b/src/prms/Main_prms.f90
@@ -92,6 +92,7 @@ program prms6
   call Control_data%param_file_hdl%close()
 
   ! Run the simulation
+  write(*,*) "main before sim"
   call model_simulation%run(Control_data)
 
   ! TODO: Open, position, and read any ancillary data including:
@@ -113,7 +114,9 @@ program prms6
     write(output_unit, fmt='(a, 1x, f16.4, 1x, a)') 'Elapsed system clock:', delta_rtc_sec, 'seconds.'
     write(output_unit, fmt='(a, 1x, f16.4, 1x, a)') 'Elapsed cpu time:', end_ct - start_ct, 'seconds.'
   endif
-contains
+    contains
+    
+    
 
   !***********************************************************************
   ! Get Control File from command line or user interaction.

--- a/src/prms/Main_prms.f90
+++ b/src/prms/Main_prms.f90
@@ -113,7 +113,7 @@ program prms6
     write(output_unit, fmt='(a, 1x, f16.4, 1x, a)') 'Elapsed system clock:', delta_rtc_sec, 'seconds.'
     write(output_unit, fmt='(a, 1x, f16.4, 1x, a)') 'Elapsed cpu time:', end_ct - start_ct, 'seconds.'
   endif
-    contains
+contains
     
     
 

--- a/src/prms/Main_prms.f90
+++ b/src/prms/Main_prms.f90
@@ -92,7 +92,6 @@ program prms6
   call Control_data%param_file_hdl%close()
 
   ! Run the simulation
-  write(*,*) "main before sim"
   call model_simulation%run(Control_data)
 
   ! TODO: Open, position, and read any ancillary data including:

--- a/src/prmslib/misc/sm_simulation.f90
+++ b/src/prmslib/misc/sm_simulation.f90
@@ -102,7 +102,6 @@ submodule (Simulation_class) sm_simulation
       class(Simulation), intent(inout) :: this
       type(Control), intent(in) :: ctl_data
 
-      write(*,*) 'before simulation'
       ! ------------------------------------------------------------------------
       do
         if (.not. this%model_time%next(ctl_data)) exit

--- a/src/prmslib/misc/sm_simulation.f90
+++ b/src/prmslib/misc/sm_simulation.f90
@@ -16,7 +16,7 @@ submodule (Simulation_class) sm_simulation
       ! this%model_basin = Basin(ctl_data)
       ! this%model_time = Time_t(ctl_data, this%model_basin%hemisphere)
 
-     this%model_time = Time_t(ctl_data)
+      this%model_time = Time_t(ctl_data)
       this%model_basin = Basin(ctl_data)
       call this%model_time%set_hemisphere(this%model_basin%hemisphere)
 

--- a/src/prmslib/misc/sm_simulation.f90
+++ b/src/prmslib/misc/sm_simulation.f90
@@ -16,7 +16,7 @@ submodule (Simulation_class) sm_simulation
       ! this%model_basin = Basin(ctl_data)
       ! this%model_time = Time_t(ctl_data, this%model_basin%hemisphere)
 
-      this%model_time = Time_t(ctl_data)
+     this%model_time = Time_t(ctl_data)
       this%model_basin = Basin(ctl_data)
       call this%model_time%set_hemisphere(this%model_basin%hemisphere)
 
@@ -102,6 +102,7 @@ submodule (Simulation_class) sm_simulation
       class(Simulation), intent(inout) :: this
       type(Control), intent(in) :: ctl_data
 
+      write(*,*) 'before simulation'
       ! ------------------------------------------------------------------------
       do
         if (.not. this%model_time%next(ctl_data)) exit

--- a/src/prmslib/physics/c_precipitation.f90
+++ b/src/prmslib/physics/c_precipitation.f90
@@ -92,13 +92,14 @@ module PRMS_PRECIPITATION
   ! end interface
 
   interface
-    module subroutine run_Precipitation(this, ctl_data, model_basin, model_temp, model_time, model_summary)
+    module subroutine run_Precipitation(this, ctl_data, model_basin, model_temp, model_time, model_summary, precip_in)
       class(Precipitation), intent(inout) :: this
       type(Control), intent(in) :: ctl_data
       type(Basin), intent(in) :: model_basin
       class(Temperature), intent(in) :: model_temp
       type(Time_t), intent(in), optional :: model_time
       type(Summary), intent(inout) :: model_summary
+      logical, intent(in), optional :: precip_in
     end subroutine
   end interface
 

--- a/src/prmslib/physics/c_precipitation_hru.f90
+++ b/src/prmslib/physics/c_precipitation_hru.f90
@@ -53,13 +53,14 @@ module PRMS_PRECIPITATION_HRU
   end interface
 
   interface
-    module subroutine run_Precipitation_hru(this, ctl_data, model_basin, model_temp, model_time, model_summary)
+    module subroutine run_Precipitation_hru(this, ctl_data, model_basin, model_temp, model_time, model_summary, precip_in)
       class(Precipitation_hru), intent(inout) :: this
       type(Control), intent(in) :: ctl_data
       type(Basin), intent(in) :: model_basin
       class(Temperature), intent(in) :: model_temp
       type(Time_t), intent(in), optional :: model_time
       type(Summary), intent(inout) :: model_summary
+      logical, intent(in), optional :: precip_in
     end subroutine
   end interface
 

--- a/src/prmslib/physics/c_temperature.f90
+++ b/src/prmslib/physics/c_temperature.f90
@@ -70,12 +70,13 @@ module PRMS_TEMPERATURE
   ! end interface
 
   interface
-    module subroutine run_Temperature(this, ctl_data, model_basin, model_time, model_summary)
+    module subroutine run_Temperature(this, ctl_data, model_basin, model_time, model_summary, tmax_in, tmin_in)
       class(Temperature), intent(inout) :: this
       type(Control), intent(in) :: ctl_data
       type(Basin), intent(in) :: model_basin
       type(Time_t), intent(in), optional :: model_time
       type(Summary), intent(inout) :: model_summary
+      logical, intent(in), optional :: tmax_in, tmin_in
     end subroutine
   end interface
 

--- a/src/prmslib/physics/c_temperature_hru.f90
+++ b/src/prmslib/physics/c_temperature_hru.f90
@@ -67,12 +67,14 @@ module PRMS_TEMPERATURE_HRU
   ! end interface
 
   interface
-    module subroutine run_Temperature_hru(this, ctl_data, model_basin, model_time, model_summary)
+    module subroutine run_Temperature_hru(this, ctl_data, model_basin, model_time, model_summary, tmax_in, tmin_in)
       class(Temperature_hru), intent(inout) :: this
       type(Control), intent(in) :: ctl_data
       type(Basin), intent(in) :: model_basin
       type(Time_t), intent(in), optional :: model_time
       type(Summary), intent(inout) :: model_summary
+      logical, intent(in), optional :: tmax_in, tmin_in
     end subroutine
+
   end interface
 end module

--- a/src/prmslib/physics/sm_precipitation.f90
+++ b/src/prmslib/physics/sm_precipitation.f90
@@ -141,14 +141,14 @@ contains
     end associate
   end subroutine
 
-  module subroutine run_Precipitation(this, ctl_data, model_basin, model_temp, model_time, model_summary)
+  module subroutine run_Precipitation(this, ctl_data, model_basin, model_temp, model_time, model_summary, precip_in)
     class(Precipitation), intent(inout) :: this
     type(Control), intent(in) :: ctl_data
     type(Basin), intent(in) :: model_basin
     class(Temperature), intent(in) :: model_temp
     type(Time_t), intent(in), optional :: model_time
     type(Summary), intent(inout) :: model_summary
-
+    logical, intent(in), optional :: precip_in
     ! --------------------------------------------------------------------------
   end subroutine
 

--- a/src/prmslib/physics/sm_srunoff.f90
+++ b/src/prmslib/physics/sm_srunoff.f90
@@ -142,19 +142,18 @@ submodule (PRMS_SRUNOFF) sm_srunoff
         allocate(this%infil(nhru))
         allocate(this%sroff(nhru))
 
-        !if (cascade_flag == 1) then
+        if (cascade_flag == 1) then
           ! Cascading variables
           allocate(this%upslope_hortonian(nhru))
           allocate(this%hru_hortn_cascflow(nhru))
           this%upslope_hortonian = 0.0_dp
           this%hru_hortn_cascflow = 0.0_dp
 
-          !if (nlake > 0) then ! rmcd causes bmi to crash when getting hortonian lakes if it's undefined
-                                ! I don't think there is any harm in allocating and setting to zero
+          if (nlake > 0) then 
             allocate(this%hortonian_lakes(nhru))
             this%hortonian_lakes = 0.0_dp
-          !endif
-        !endif
+          endif
+        endif
 
         if (cascade_flag == 1 .or. cascadegw_flag > 0) then
           allocate(this%strm_seg_in(nsegment))

--- a/src/prmslib/physics/sm_srunoff.f90
+++ b/src/prmslib/physics/sm_srunoff.f90
@@ -142,18 +142,19 @@ submodule (PRMS_SRUNOFF) sm_srunoff
         allocate(this%infil(nhru))
         allocate(this%sroff(nhru))
 
-        if (cascade_flag == 1) then
+        !if (cascade_flag == 1) then
           ! Cascading variables
           allocate(this%upslope_hortonian(nhru))
           allocate(this%hru_hortn_cascflow(nhru))
           this%upslope_hortonian = 0.0_dp
           this%hru_hortn_cascflow = 0.0_dp
 
-          if (nlake > 0) then
+          !if (nlake > 0) then ! rmcd causes bmi to crash when getting hortonian lakes if it's undefined
+                                ! I don't think there is any harm in allocating and setting to zero
             allocate(this%hortonian_lakes(nhru))
             this%hortonian_lakes = 0.0_dp
-          endif
-        endif
+          !endif
+        !endif
 
         if (cascade_flag == 1 .or. cascadegw_flag > 0) then
           allocate(this%strm_seg_in(nsegment))
@@ -457,7 +458,7 @@ submodule (PRMS_SRUNOFF) sm_srunoff
         this%hru_sroffi = 0.0
         this%hru_sroffp = 0.0
         ! check_dprst = .false.
-
+        write(*,*) 'before hru loop'
         do k=1, active_hrus
           chru = hru_route_order(k)
           runoff = 0.0_dp

--- a/src/prmslib/physics/sm_srunoff.f90
+++ b/src/prmslib/physics/sm_srunoff.f90
@@ -458,7 +458,6 @@ submodule (PRMS_SRUNOFF) sm_srunoff
         this%hru_sroffi = 0.0
         this%hru_sroffp = 0.0
         ! check_dprst = .false.
-        write(*,*) 'before hru loop'
         do k=1, active_hrus
           chru = hru_route_order(k)
           runoff = 0.0_dp

--- a/src/prmslib/physics/sm_temperature.f90
+++ b/src/prmslib/physics/sm_temperature.f90
@@ -95,7 +95,7 @@ contains
     end associate
   end subroutine
 
-  module subroutine run_Temperature(this, ctl_data, model_basin, model_time, model_summary)
+  module subroutine run_Temperature(this, ctl_data, model_basin, model_time, model_summary, tmax_in, tmin_in)
     implicit none
 
     class(Temperature), intent(inout) :: this
@@ -103,7 +103,7 @@ contains
     type(Basin), intent(in) :: model_basin
     type(Time_t), intent(in), optional :: model_time
     type(Summary), intent(inout) :: model_summary
-
+    logical, intent(in), optional :: tmax_in, tmin_in
     ! --------------------------------------------------------------------------
   end subroutine
 


### PR DESCRIPTION
Optional vars indicate whether tmax, tmin, or hru_ppt have been set by the bmi setter functions and if so then these functions won't read tmax, tmin, or hru_ppt from file.  Because the vars are optional it should not effect base prms function. At anyrate I think we should proceed with these changes to 6.0.0_dev_bmi.  I think the last two commits are the ones to inspect with some care.  