### PR TITLE
potential fix for runtime error with coupled bmi's in gfortran

### DIFF
--- a/src/prmslib/classes/sm_control.f90
+++ b/src/prmslib/classes/sm_control.f90
@@ -222,11 +222,12 @@ contains
 
     module subroutine cleanup_control(this)
       class(Control) :: this
+      integer(i32) :: istat 
         !! Srunoff class
 
       logical :: is_opened
 
-       inquire(UNIT=this%model_output_unit, OPENED=is_opened)
+       inquire(UNIT=this%model_output_unit, OPENED=is_opened, iostat=istat)
        if (is_opened) then
          close(this%model_output_unit)
        end if


### PR DESCRIPTION
@mdpiper 

when running a coupled bmi model with the surface and soil bmi's (see example code below), I get the following runtime error on finalize with the soil-bmi: **Fortran runtime error: Inquire statement identifies an internal file**.  See also the Fortran function where runtime error occurs below. THere is some indication that this is actually a gfortran bug that is fixed in v8.1 but also it looks like this pull request may have a simple fix as well.  

Question?:  Mark do you have a recipe for compiling and installing with the conda env  like the pymt_ versions so I could test this change?


simple example python code: 
``` Python
from pymt.models import PRMSSurface, PRMSSoil
from pathlib import Path

run_dir = '../prms/pipestem'
config_surf = 'control_surface.simple1'
config_soil = 'control_soil.simple1'
print(Path(run_dir).exists())
print((Path(run_dir) / config_surf).exists())
print((Path(run_dir) / config_soil).exists())

msurf = PRMSSurface()
msoil = PRMSSoil()

print(msoil.name)

msurf.initialize(config_surf, run_dir)
msoil.initialize(config_soil, run_dir)

msurf.update()
msoil.update()

msoil.finalize()
msurf.finalize()
```

``` Fortran
    module subroutine cleanup_control(this)
      class(Control) :: this
        !! Srunoff class

      logical :: is_opened

       inquire(UNIT=this%model_output_unit, OPENED=is_opened)
       if (is_opened) then
         close(this%model_output_unit)
       end if
    end subroutine
```